### PR TITLE
Update target framework to .NET 10.0 across all project files

### DIFF
--- a/src/DunderMifflin.Api/DunderMifflin.Api.csproj
+++ b/src/DunderMifflin.Api/DunderMifflin.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/DunderMifflin.Mcp.Local/DunderMifflin.Mcp.Local.csproj
+++ b/src/DunderMifflin.Mcp.Local/DunderMifflin.Mcp.Local.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/DunderMifflin.Mcp.Remote/DunderMifflin.Mcp.Remote.csproj
+++ b/src/DunderMifflin.Mcp.Remote/DunderMifflin.Mcp.Remote.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/DunderMifflin.Shared/DunderMifflin.Shared.csproj
+++ b/src/DunderMifflin.Shared/DunderMifflin.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/DunderMifflin.Tests/DunderMifflin.Tests.csproj
+++ b/src/DunderMifflin.Tests/DunderMifflin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This pull request updates the target framework for all projects in the solution from .NET 9.0 to .NET 10.0. This change ensures that all components are built and run using the latest .NET platform, enabling access to new language features and runtime improvements.

**Target framework upgrades:**

* Updated `TargetFramework` to `net10.0` in `DunderMifflin.Api.csproj`
* Updated `TargetFramework` to `net10.0` in `DunderMifflin.Mcp.Local.csproj`
* Updated `TargetFramework` to `net10.0` in `DunderMifflin.Mcp.Remote.csproj`
* Updated `TargetFramework` to `net10.0` in `DunderMifflin.Shared.csproj`
* Updated `TargetFramework` to `net10.0` in `DunderMifflin.Tests.csproj`